### PR TITLE
Fix iPhone notch white background in PWA

### DIFF
--- a/swipe-game.html
+++ b/swipe-game.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Swipe Game</title>
     
     <!-- PWA Meta Tags -->
@@ -24,6 +24,18 @@
         body {
             overflow: hidden;
             touch-action: none;
+            padding-top: env(safe-area-inset-top);
+            padding-left: env(safe-area-inset-left);
+            padding-right: env(safe-area-inset-right);
+            padding-bottom: env(safe-area-inset-bottom);
+        }
+        
+        #gameContainer {
+            height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+            padding-top: 0;
+            padding-left: 0;
+            padding-right: 0;
+            padding-bottom: 0;
         }
         
         .square {


### PR DESCRIPTION
## Summary
• Fixes white background appearing around iPhone notch when PWA is used on devices with notches
• Adds proper safe area handling for iPhone X and later models
• Ensures game extends to full screen while keeping content accessible

## Changes Made
• Added `viewport-fit=cover` to viewport meta tag to extend content behind notch
• Added CSS safe area insets using `env(safe-area-inset-*)` variables
• Updated game container height calculation to account for safe areas
• Applied safe area padding to body element

## Test Plan
- [ ] Test on iPhone with notch (iPhone X, 11, 12, 13, 14, 15 series)
- [ ] Install PWA and verify no white background around notch
- [ ] Confirm game content doesn't overlap with status bar/notch
- [ ] Test swipe interactions work properly in safe areas
- [ ] Verify game still works on non-notch devices

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)